### PR TITLE
fix: post v3 bug fixing (ACQ-1673)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Apto PCI SDK interactive example</title>
 		<!-- Use this to work locally: -->
-		<script src="./packages/pci-sdk-web/dist/umd/apto-pci-sdk.js"></script>
-		<!-- <script src="https://cdn.jsdelivr.net/npm/@apto-payments/pci-sdk-web"></script> -->
+		<!-- <script src="./packages/pci-sdk-web/dist/umd/apto-pci-sdk.js"></script> -->
+		<script src="https://cdn.jsdelivr.net/npm/@apto-payments/pci-sdk-web"></script>
 
 		<style>
 			* {

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Apto PCI SDK interactive example</title>
 		<!-- Use this to work locally: -->
-		<!-- <script src="./packages//pci-sdk-web/dist/umd/apto-pci-sdk.js"></script> -->
-		<script src="https://cdn.jsdelivr.net/npm/@apto-payments/pci-sdk-web"></script>
+		<script src="./packages/pci-sdk-web/dist/umd/apto-pci-sdk.js"></script>
+		<!-- <script src="https://cdn.jsdelivr.net/npm/@apto-payments/pci-sdk-web"></script> -->
 
 		<style>
 			* {

--- a/packages/pci-sdk-iframe/src/pages/app/App.tsx
+++ b/packages/pci-sdk-iframe/src/pages/app/App.tsx
@@ -28,7 +28,7 @@ export default function App() {
 		<>
 			<Info message={message} />
 			{isFormVisible ? (
-				<Form handleSubmit={handleCodeSubmit} placeholder={codePlaceholderMessage} />
+				<Form handleSubmit={handleCodeSubmit} placeholder={codePlaceholderMessage} theme={theme} />
 			) : (
 				<CardData
 					isLoading={isLoading}

--- a/packages/pci-sdk-iframe/src/pages/app/components/Form/Form.tsx
+++ b/packages/pci-sdk-iframe/src/pages/app/components/Form/Form.tsx
@@ -1,38 +1,22 @@
 import React from 'react';
+import { ITheme } from '../../../../types/IThemes';
 
 interface IFormProps {
 	handleSubmit: (e: React.FormEvent) => void;
 	placeholder: string;
+	theme: ITheme;
 }
 
 export default function Form(props: IFormProps) {
 	return (
-		<form
-			style={{
-				alignContent: 'center',
-				display: 'flex',
-				flexDirection: 'column',
-				height: '100%',
-				justifyContent: 'center',
-				padding: '5vw',
-			}}
-			onSubmit={props.handleSubmit}
-			data-testid="2fa-form"
-		>
+		<form style={props.theme.form2FA} onSubmit={props.handleSubmit} data-testid="2fa-form">
 			<div
 				style={{
 					display: 'flex',
 				}}
 			>
 				<input
-					style={{
-						width: '90%',
-						margin: 'auto',
-						fontSize: '4.7vw', //'16px',
-						padding: '2.35vw', //'16px',
-						borderRadius: '1.2vw 0 0 1.2vw',
-						border: '1px solid #ccc',
-					}}
+					style={props.theme.form2FAInput}
 					autoComplete="off"
 					required
 					id="code"
@@ -41,17 +25,8 @@ export default function Form(props: IFormProps) {
 					aria-label="2FA code"
 					placeholder={props.placeholder}
 				/>
-				<button
-					style={{
-						cursor: 'pointer',
-						padding: '0 1rem',
-						borderRadius: '0 1.2vw 1.2vw 0',
-						border: '1px solid #ccc',
-					}}
-					type="submit"
-				>
-					{' '}
-					OK{' '}
+				<button style={props.theme.form2FASubmit} type="submit">
+					Send
 				</button>
 			</div>
 		</form>

--- a/packages/pci-sdk-iframe/src/pages/app/components/Form/Form.tsx
+++ b/packages/pci-sdk-iframe/src/pages/app/components/Form/Form.tsx
@@ -9,14 +9,14 @@ interface IFormProps {
 
 export default function Form(props: IFormProps) {
 	return (
-		<form style={props.theme.form2FA} onSubmit={props.handleSubmit} data-testid="2fa-form">
+		<form style={props.theme.formOTP} onSubmit={props.handleSubmit} data-testid="2fa-form">
 			<div
 				style={{
 					display: 'flex',
 				}}
 			>
 				<input
-					style={props.theme.form2FAInput}
+					style={props.theme.formOTPInput}
 					autoComplete="off"
 					required
 					id="code"
@@ -25,7 +25,7 @@ export default function Form(props: IFormProps) {
 					aria-label="2FA code"
 					placeholder={props.placeholder}
 				/>
-				<button style={props.theme.form2FASubmit} type="submit">
+				<button style={props.theme.formOTPSubmit} type="submit">
 					Send
 				</button>
 			</div>

--- a/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
@@ -83,5 +83,7 @@ export default {
 		cursor: 'pointer',
 		fontSize: '3.53vw', // '12px'
 		color: 'white',
+		boxSizing: 'border-box',
+		margin: '0',
 	},
 };

--- a/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
@@ -1,4 +1,4 @@
-// TODO: group this with context: `cardData: { ... }, form2FA: { ... }` in the next major release
+// TODO: group this with context: `cardData: { ... }, formOTP: { ... }` in the next major release
 export default {
 	// Card Data
 	container: {
@@ -57,7 +57,7 @@ export default {
 		fontSize: '7.06vw', //24px
 	},
 	// 2FA Form
-	form2FA: {
+	formOTP: {
 		alignContent: 'center',
 		display: 'flex',
 		flexDirection: 'column',
@@ -65,7 +65,7 @@ export default {
 		justifyContent: 'center',
 		padding: '0 15vw',
 	},
-	form2FAInput: {
+	formOTPInput: {
 		width: '90%',
 		margin: 'auto',
 		fontSize: '3.53vw', // '12px'
@@ -75,7 +75,7 @@ export default {
 		border: '1px solid #424242',
 		color: 'white',
 	},
-	form2FASubmit: {
+	formOTPSubmit: {
 		padding: '0 1rem',
 		backgroundColor: '#212121',
 		border: '1px solid #000',

--- a/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/dark.ts
@@ -1,4 +1,6 @@
+// TODO: group this with context: `cardData: { ... }, form2FA: { ... }` in the next major release
 export default {
+	// Card Data
 	container: {
 		display: 'flex',
 		flexWrap: 'wrap',
@@ -53,5 +55,33 @@ export default {
 	},
 	pan: {
 		fontSize: '7.06vw', //24px
+	},
+	// 2FA Form
+	form2FA: {
+		alignContent: 'center',
+		display: 'flex',
+		flexDirection: 'column',
+		height: '100%',
+		justifyContent: 'center',
+		padding: '0 15vw',
+	},
+	form2FAInput: {
+		width: '90%',
+		margin: 'auto',
+		fontSize: '3.53vw', // '12px'
+		padding: '2.35vw',
+		backgroundColor: '#424242',
+		borderRadius: '1.2vw 0 0 1.2vw',
+		border: '1px solid #424242',
+		color: 'white',
+	},
+	form2FASubmit: {
+		padding: '0 1rem',
+		backgroundColor: '#212121',
+		border: '1px solid #000',
+		borderRadius: '0 1.2vw 1.2vw 0',
+		cursor: 'pointer',
+		fontSize: '3.53vw', // '12px'
+		color: 'white',
 	},
 };

--- a/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
@@ -1,4 +1,4 @@
-// TODO: group this with context: `cardData: { ... }, form2FA: { ... }` in the next major release
+// TODO: group this with context: `cardData: { ... }, formOTP: { ... }` in the next major release
 export default {
 	// Card Data
 	container: {
@@ -57,7 +57,7 @@ export default {
 		fontSize: '7.06vw', //24px
 	},
 	// 2FA Form
-	form2FA: {
+	formOTP: {
 		alignContent: 'center',
 		display: 'flex',
 		flexDirection: 'column',
@@ -65,7 +65,7 @@ export default {
 		justifyContent: 'center',
 		padding: '0 15vw',
 	},
-	form2FAInput: {
+	formOTPInput: {
 		width: '90%',
 		margin: 'auto',
 		fontSize: '3.53vw', // '12px'
@@ -73,7 +73,7 @@ export default {
 		borderRadius: '1.2vw 0 0 1.2vw',
 		border: '1px solid #ccc',
 	},
-	form2FASubmit: {
+	formOTPSubmit: {
 		padding: '0 1rem',
 		backgroundColor: '#ccc',
 		border: '1px solid #ccc',

--- a/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
@@ -75,9 +75,12 @@ export default {
 	},
 	form2FASubmit: {
 		padding: '0 1rem',
+		backgroundColor: '#ccc',
 		border: '1px solid #ccc',
 		borderRadius: '0 1.2vw 1.2vw 0',
 		cursor: 'pointer',
 		fontSize: '3.53vw', // '12px'
+		boxSizing: 'border-box',
+		margin: '0',
 	},
 };

--- a/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/themes/light.ts
@@ -1,4 +1,6 @@
+// TODO: group this with context: `cardData: { ... }, form2FA: { ... }` in the next major release
 export default {
+	// Card Data
 	container: {
 		display: 'flex',
 		flexWrap: 'wrap',
@@ -25,7 +27,7 @@ export default {
 	groupPan: {
 		order: 1,
 		width: '100%',
-		marginBottom: '3.53vw', //'12px'
+		marginBottom: '3.53vw', // '12px'
 	},
 	groupCvv: {
 		order: 4,
@@ -53,5 +55,29 @@ export default {
 	},
 	pan: {
 		fontSize: '7.06vw', //24px
+	},
+	// 2FA Form
+	form2FA: {
+		alignContent: 'center',
+		display: 'flex',
+		flexDirection: 'column',
+		height: '100%',
+		justifyContent: 'center',
+		padding: '0 15vw',
+	},
+	form2FAInput: {
+		width: '90%',
+		margin: 'auto',
+		fontSize: '3.53vw', // '12px'
+		padding: '2.35vw',
+		borderRadius: '1.2vw 0 0 1.2vw',
+		border: '1px solid #ccc',
+	},
+	form2FASubmit: {
+		padding: '0 1rem',
+		border: '1px solid #ccc',
+		borderRadius: '0 1.2vw 1.2vw 0',
+		cursor: 'pointer',
+		fontSize: '3.53vw', // '12px'
 	},
 };

--- a/packages/pci-sdk-iframe/src/pages/app/useApp.ts
+++ b/packages/pci-sdk-iframe/src/pages/app/useApp.ts
@@ -41,7 +41,7 @@ export default function useApp() {
 
 	useEffect(() => {
 		function _onMessage(event: MessageEvent) {
-			const data = JSON.parse(event.data);
+			const data = event?.data ? JSON.parse(event.data) : {};
 
 			switch (data.type) {
 				case 'setStyle':
@@ -59,6 +59,7 @@ export default function useApp() {
 						message: '',
 						isFormVisible: false,
 						verificationId: '',
+						isLoading: false,
 					});
 				case 'isDataVisible':
 					return messageService.emitMessage({

--- a/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
+++ b/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
@@ -113,7 +113,7 @@ const dummy_style_default_theme_extended: ITheme = {
 	cvv: {
 		fontSize: '24px',
 	},
-	form2FA: {
+	formOTP: {
 		alignContent: 'center',
 		display: 'flex',
 		flexDirection: 'column',
@@ -121,7 +121,7 @@ const dummy_style_default_theme_extended: ITheme = {
 		justifyContent: 'center',
 		padding: '0 15vw',
 	},
-	form2FAInput: {
+	formOTPInput: {
 		border: '1px solid #ccc',
 		borderRadius: '1.2vw 0 0 1.2vw',
 		fontSize: '3.53vw',
@@ -129,7 +129,7 @@ const dummy_style_default_theme_extended: ITheme = {
 		padding: '2.35vw',
 		width: '90%',
 	},
-	form2FASubmit: {
+	formOTPSubmit: {
 		backgroundColor: '#ccc',
 		border: '1px solid #ccc',
 		borderRadius: '0 1.2vw 1.2vw 0',

--- a/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
+++ b/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
@@ -130,10 +130,13 @@ const dummy_style_default_theme_extended: ITheme = {
 		width: '90%',
 	},
 	form2FASubmit: {
+		backgroundColor: '#ccc',
 		border: '1px solid #ccc',
 		borderRadius: '0 1.2vw 1.2vw 0',
 		cursor: 'pointer',
 		fontSize: '3.53vw',
 		padding: '0 1rem',
+		boxSizing: 'border-box',
+		margin: '0',
 	},
 };

--- a/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
+++ b/packages/pci-sdk-iframe/src/services/theme.service.spec.ts
@@ -113,4 +113,27 @@ const dummy_style_default_theme_extended: ITheme = {
 	cvv: {
 		fontSize: '24px',
 	},
+	form2FA: {
+		alignContent: 'center',
+		display: 'flex',
+		flexDirection: 'column',
+		height: '100%',
+		justifyContent: 'center',
+		padding: '0 15vw',
+	},
+	form2FAInput: {
+		border: '1px solid #ccc',
+		borderRadius: '1.2vw 0 0 1.2vw',
+		fontSize: '3.53vw',
+		margin: 'auto',
+		padding: '2.35vw',
+		width: '90%',
+	},
+	form2FASubmit: {
+		border: '1px solid #ccc',
+		borderRadius: '0 1.2vw 1.2vw 0',
+		cursor: 'pointer',
+		fontSize: '3.53vw',
+		padding: '0 1rem',
+	},
 };

--- a/packages/pci-sdk-iframe/src/types/IThemes.d.ts
+++ b/packages/pci-sdk-iframe/src/types/IThemes.d.ts
@@ -16,7 +16,7 @@ export interface ITheme {
 	pan?: CSSProperties;
 	cvv?: CSSProperties;
 	exp?: CSSProperties;
-	form2FA?: CSSProperties;
-	form2FAInput?: CSSProperties;
-	form2FASubmit?: CSSProperties;
+	formOTP?: CSSProperties;
+	formOTPInput?: CSSProperties;
+	formOTPSubmit?: CSSProperties;
 }

--- a/packages/pci-sdk-iframe/src/types/IThemes.d.ts
+++ b/packages/pci-sdk-iframe/src/types/IThemes.d.ts
@@ -16,4 +16,7 @@ export interface ITheme {
 	pan?: CSSProperties;
 	cvv?: CSSProperties;
 	exp?: CSSProperties;
+	form2FA?: CSSProperties;
+	form2FAInput?: CSSProperties;
+	form2FASubmit?: CSSProperties;
 }


### PR DESCRIPTION
## Summary 💭

This fixes two issues:
- `iframe` growing unexpectedly when displaying the **OTP Form**
- view stuck on `loading` when hiding the PCI data

### Unexpected growing

<img width="200" alt="Screenshot 2021-08-04 at 10 29 35" src="https://user-images.githubusercontent.com/5938217/128191023-0b84e3da-0f3a-4a1c-a706-6203fa809757.png">

The height of the [`<Form />`](https://github.com/AptoPayments/apto-pci-sdk-web/blob/dev/packages/pci-sdk-iframe/src/pages/app/components/Form/Form.tsx#L8-L59) component was bigger than the [`<CardData />`](https://github.com/AptoPayments/apto-pci-sdk-web/blob/dev/packages/pci-sdk-iframe/src/pages/app/components/CardData/CardData.tsx#L17-L69) one. 

In Android, this resulted in the `<div />` wrapping the SDK grow but not shrink later when displaying the card details and hence keeping an extra space at the bottom of the card...

To resolve this we just had to remove the `padding` from `<Form />` as it was already naturally centred by `display: flex`.

### Stuck on loading

<img src="https://user-images.githubusercontent.com/5938217/128192626-76758c3a-e368-4d67-9fa8-ac59e9b4ef8b.gif" width="400" />

When asking the iframe to **hide the PCI data**, sometimes the view would get stuck on the loading state.
This was because we didn't clean the `loading` flag on the state when hiding the PCI data.

### Other updates

<img width="537" alt="Screenshot 2021-08-04 at 15 53 47" src="https://user-images.githubusercontent.com/5938217/128193181-f9a3c525-8207-40b8-94ff-7a12e1dc9af8.png">

We added a default dark theme for the **OTP Form** and added options to customise it on the client level through:
```js
{
  theme: {
    formOTP: { ... } ;
    formOTPInput: { ... };
    formOTPSubmit: { ... };
```
